### PR TITLE
rsync support multiple volumes

### DIFF
--- a/pkg/rsync/entrypoint.sh
+++ b/pkg/rsync/entrypoint.sh
@@ -1,8 +1,10 @@
 #!/bin/sh
 VOLUME=${VOLUME:-/volume}
+VOLUMES=${VOLUMES:-$VOLUME}
 ALLOW=${ALLOW:-192.168.0.0/16 172.16.0.0/12}
 USER=${USER:-nobody}
 GROUP=${GROUP:-nogroup}
+CONF_FILE=${CONF_FILE:-"/tmp/rsyncd.conf"}
 
 mkdir -p ${VOLUME}
 
@@ -10,18 +12,23 @@ getent group ${GROUP} > /dev/null || addgroup ${GROUP}
 getent passwd ${USER} > /dev/null || adduser -D -H -G ${GROUP} ${USER}
 chown -R ${USER}:${GROUP} ${VOLUME}
 
-cat <<EOF > /etc/rsyncd.conf
+cat <<EOF > ${CONF_FILE}
 uid = ${USER}
 gid = ${GROUP}
 use chroot = yes
 log file = /dev/stdout
 reverse lookup = no
-[volume]
+EOF
+
+for volume in $VOLUMES; do
+cat <<EOF >> ${CONF_FILE}
+[${volume}]
     hosts deny = *
     hosts allow = ${ALLOW}
     read only = false
-    path = ${VOLUME}
-    comment = docker volume
+    path = ${volume}
+    comment = container mount ${volume}
 EOF
+done
 
-exec /usr/bin/rsync --no-detach --daemon --config /etc/rsyncd.conf
+exec /usr/bin/rsync --no-detach --daemon --config ${CONF_FILE}


### PR DESCRIPTION
Added to rsync package support for having multiple volumes through
VOLUMES environment variable. Keeping backward support for the
VOLUME environment variable.